### PR TITLE
멘션 동명이인 방지

### DIFF
--- a/vendor/laravel/socialite/src/Two/FacebookProvider.php
+++ b/vendor/laravel/socialite/src/Two/FacebookProvider.php
@@ -113,9 +113,12 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
 
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => null, 'name' => isset($user['name']) ? $user['name'] : null,
-            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $avatarUrl.'?type=normal',
-            'avatar_original' => $avatarUrl.'?width=1920',
+            'id' => $user['id'], 
+            'nickname' => null, 
+            'name' => isset($user['name']) ? $user['name'].'f'.$user['id'] : null,
+            'email' => isset($user['email']) ? $user['email'] : null, 
+            'image' => $avatarUrl.'?type=normal',
+            'image_original' => $avatarUrl.'?width=1920',
         ]);
     }
 

--- a/vendor/socialiteproviders/naver/src/NaverProvider.php
+++ b/vendor/socialiteproviders/naver/src/NaverProvider.php
@@ -95,7 +95,7 @@ class NaverProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User())->setRaw($user)->map([
             'id' => $user['id'],
-            'name' => $user['name'],
+            'name' => $user['name'].'n'.$user['id'],
             'email' => $user['email'],
             'image' => $user['profile_image'],
         ]);


### PR DESCRIPTION
- 회원가입시 아이디코드를 뒤에 붙이도록하여 멘션에서 같은 닉네임을 찾아 DB에 넣는 오류 방지
